### PR TITLE
Added include to NonlinearSystemBase.h

### DIFF
--- a/include/StressDivergenceCurvedBeam.h
+++ b/include/StressDivergenceCurvedBeam.h
@@ -11,6 +11,7 @@
 
 #include "Kernel.h"
 #include "RankTwoTensorForward.h"
+#include "NonlinearSystemBase.h"
 
 class StressDivergenceCurvedBeam : public Kernel
 {


### PR DESCRIPTION
After updating Moose, an include to NonlinearSystemBase.h is needed (otherwise your MooseApp will not compile). No functional changes.